### PR TITLE
Module Exports

### DIFF
--- a/exp_util/module/module_exports.lua
+++ b/exp_util/module/module_exports.lua
@@ -420,7 +420,7 @@ function ExpUtil.get_storage_for_stack(options)
     local current, count, entities = cache.current, cache.count, cache.entities
     for i = 1, cache.count do
         local entity = entities[((current + i - 1) % count) + 1]
-        if entity.can_insert(item) then
+        if entity and entity.can_insert(item) then
             cache.current = current + 1
             return entity
         end

--- a/exp_util/module/module_exports.lua
+++ b/exp_util/module/module_exports.lua
@@ -420,21 +420,8 @@ function ExpUtil.get_storage_for_stack(options)
     local current, count, entities = cache.current, cache.count, cache.entities
     for i = 1, cache.count do
         local entity = entities[((current + i - 1) % count) + 1]
-        local entity = entities[((current + i - 1) % count) + 1]
-        --[[
-            PR 349 https://github.com/explosivegaming/ExpCluster/pull/349
-
-            Error while running event level::on_character_corpse_expired (ID 103)
-            level/modules/exp_util/module_exports.lua:423: attempt to index local 'entity' (a nil value)
-            stack traceback:
-            level/modules/exp_util/module_exports.lua:423: in function 'get_storage_for_stack'
-            level/modules/exp_util/module_exports.lua:462: in function 'copy_items_to_surface'
-            level/modules/exp_util/module_exports.lua:495: in function 'transfer_inventory_to_surface'
-            ...vel__/modules/exp_legacy/modules/addons/death-logger.lua:155: in function 'handler'
-            level/modules/exp_legacy/utils/event.lua:22: in function 'handler'
-            core/lualib/event_handler.lua:47: in function <core/lualib/event_handler.lua:45>
-        ]]
         if entity == nil then
+            -- See Github Issue #352 <https://github.com/explosivegaming/ExpCluster/issues/352>
             error("entity was nil, context:\n" .. ExpUtil.format_any({
                 cache = cache,
                 i = i,

--- a/exp_util/module/module_exports.lua
+++ b/exp_util/module/module_exports.lua
@@ -420,7 +420,30 @@ function ExpUtil.get_storage_for_stack(options)
     local current, count, entities = cache.current, cache.count, cache.entities
     for i = 1, cache.count do
         local entity = entities[((current + i - 1) % count) + 1]
-        if entity and entity.can_insert(item) then
+        local entity = entities[((current + i - 1) % count) + 1]
+        --[[
+            PR 349 https://github.com/explosivegaming/ExpCluster/pull/349
+
+            Error while running event level::on_character_corpse_expired (ID 103)
+            level/modules/exp_util/module_exports.lua:423: attempt to index local 'entity' (a nil value)
+            stack traceback:
+            level/modules/exp_util/module_exports.lua:423: in function 'get_storage_for_stack'
+            level/modules/exp_util/module_exports.lua:462: in function 'copy_items_to_surface'
+            level/modules/exp_util/module_exports.lua:495: in function 'transfer_inventory_to_surface'
+            ...vel__/modules/exp_legacy/modules/addons/death-logger.lua:155: in function 'handler'
+            level/modules/exp_legacy/utils/event.lua:22: in function 'handler'
+            core/lualib/event_handler.lua:47: in function <core/lualib/event_handler.lua:45>
+        ]]
+        if entity == nil then
+            error("entity was nil, context:\n" .. ExpUtil.format_any({
+                cache = cache,
+                i = i,
+            }, {
+                max_line_count = 0,
+                no_locale_strings = true
+            }))
+        end
+        if entity.can_insert(item) then
             cache.current = current + 1
             return entity
         end


### PR DESCRIPTION
Error while running event level::on_character_corpse_expired (ID 103)
__level__/modules/exp_util/module_exports.lua:423: attempt to index local 'entity' (a nil value)
stack traceback:
    __level__/modules/exp_util/module_exports.lua:423: in function 'get_storage_for_stack'
    __level__/modules/exp_util/module_exports.lua:462: in function 'copy_items_to_surface'
    __level__/modules/exp_util/module_exports.lua:495: in function 'transfer_inventory_to_surface'
    ...vel__/modules/exp_legacy/modules/addons/death-logger.lua:155: in function 'handler'
    __level__/modules/exp_legacy/utils/event.lua:22: in function 'handler'
    __core__/lualib/event_handler.lua:47: in function <__core__/lualib/event_handler.lua:45>