### PR TITLE
EXP GUI Tree Decon

### DIFF
--- a/exp_legacy/module/modules/addons/tree-decon.lua
+++ b/exp_legacy/module/modules/addons/tree-decon.lua
@@ -43,8 +43,7 @@ Gui.toolbar.create_button{
     visible = function(player, _)
         return Roles.player_allowed(player, "fast-tree-decon")
     end
-}:on_click(function(def, event, element)
-    local player = Gui.get_player(event)
+}:on_click(function(def, player, element)
     local state = Gui.toolbar.get_button_toggled_state(def, player)
     HasEnabledDecon:set(player, state)
     player.print{ "tree-decon.toggle-msg", state and { "tree-decon.enabled" } or { "tree-decon.disabled" } }


### PR DESCRIPTION
Error while running event level::on_gui_click (ID 1)
LuaPlayer doesn't contain key player_index.
stack traceback:
    [C]: in function '__index'
    __level__/modules/exp_gui/control.lua:40: in function 'get_player'
    __level__/modules/exp_legacy/modules/addons/tree-decon.lua:47: in function 'handler'
    __level__/modules/exp_gui/prototype.lua:406: in function 'raise_event'
    __level__/modules/exp_gui/prototype.lua:391: in function 'handler'
    __core__/lualib/event_handler.lua:47: in function <__core__/lualib/event_handler.lua:45>