### PR TITLE
Command Research

### DIFF
--- a/exp_scenario/module/commands/research.lua
+++ b/exp_scenario/module/commands/research.lua
@@ -71,7 +71,9 @@ local function on_research_finished(event)
     if not research.res_queue_enable then return end
 
     local force = event.research.force
-    if config.bonus_inventory.res[config.mod_set] and force.technologies[config.bonus_inventory.res[config.mod_set].name] and force.technologies[config.bonus_inventory.res[config.mod_set].name].level > config.bonus_inventory.res[config.mod_set].level then
+    local research = assert(config.bonus_inventory.res[config.mod_set], "Unknown mod set: " .. tostring(config.mod_set))
+    local technology = assert(force.technologies[research.name], "Unknown technology: " .. tostring(research.name))
+    if technology.level > research.level then
         module.res_queue(force, event.by_script)
     end
 end

--- a/exp_scenario/module/commands/research.lua
+++ b/exp_scenario/module/commands/research.lua
@@ -71,7 +71,7 @@ local function on_research_finished(event)
     if not research.res_queue_enable then return end
 
     local force = event.research.force
-    if force.technologies[config.bonus_inventory.res[config.mod_set].name].level > config.bonus_inventory.res[config.mod_set].level then
+    if config.bonus_inventory.res[config.mod_set] and force.technologies[config.bonus_inventory.res[config.mod_set].name] and force.technologies[config.bonus_inventory.res[config.mod_set].name].level > config.bonus_inventory.res[config.mod_set].level then
         module.res_queue(force, event.by_script)
     end
 end


### PR DESCRIPTION
The scenario level caused a non-recoverable error.
Please report this error to the scenario author.

Error while running event level::on_research_finished (ID 21)
__level__/modules/exp_scenario/commands/research.lua:74: attempt to index field '?' (a nil value)
stack traceback:
    __level__/modules/exp_scenario/commands/research.lua:74: in function 'handler'
    __core__/lualib/event_handler.lua:47: in function <__core__/lualib/event_handler.lua:45>