### PR TITLE
Spawn Area

### DIFF
--- a/exp_legacy/module/modules/addons/spawn-area.lua
+++ b/exp_legacy/module/modules/addons/spawn-area.lua
@@ -205,6 +205,9 @@ end
 if config.turrets.enabled then
     Event.on_nth_tick(config.turrets.refill_time, function()
         if game.tick < 10 then return end
+        if game.tick < (config.turrets.refill_time + 10) then
+            get_spawn_force()
+        end
         spawn_turrets()
     end)
 end


### PR DESCRIPTION
RCON ran for 18k ticks when nobody is online, there will be an error.

```
18014.527 Error ServerMultiplayerManager.cpp:84: MultiplayerManager failed: "The scenario level caused a non-recoverable error.
Please report this error to the scenario author.

Error while running event level::on_nth_tick(18000)
Unknown force: spawn
stack traceback:
    [C]: in function 'create_entity'
    __level__/modules/exp_legacy/modules/addons/spawn-area.lua:47: in function 'spawn_turrets'
    __level__/modules/exp_legacy/modules/addons/spawn-area.lua:197: in function 'handler'
    __level__/modules/exp_legacy/utils/event.lua:22: in function 'handler'
    __core__/lualib/event_handler.lua:81: in function <__core__/lualib/event_handler.lua:79>"
```