### PR TITLE
Switch to singleplayer / multiplayer init events

### DIFF
--- a/exp_commands/module/commands/ipc.lua
+++ b/exp_commands/module/commands/ipc.lua
@@ -10,6 +10,9 @@ local Clustorio = require("modules/clusterio/api")
 
 local json_to_table = helpers.json_to_table
 
+Commands.add_rcon_static("Clustorio", Clustorio)
+Commands.add_rcon_static("ipc", Clustorio.send_json)
+
 Commands.new("_ipc", { "exp-commands_ipc.description" })
     :argument("channel", { "exp-commands_ipc.arg-channel" }, Commands.types.string)
     :argument("message", { "exp-commands_ipc.arg-message" }, Commands.types.string)

--- a/exp_commands/module/commands/rcon.lua
+++ b/exp_commands/module/commands/rcon.lua
@@ -11,7 +11,6 @@ System command which runs arbitrary code within a custom (not sandboxed) environ
 local ExpUtil = require("modules/exp_util")
 local Async = require("modules/exp_util/async")
 local Storage = require("modules/exp_util/storage")
-local Clustorio = require("modules/clusterio/api")
 
 local Commands = require("modules/exp_commands") --- @class Commands
 
@@ -26,9 +25,7 @@ setmetatable(rcon_env, { __index = rcon_static })
 rcon_static.Async = Async
 rcon_static.ExpUtil = ExpUtil
 rcon_static.Commands = Commands
-rcon_static.Clustorio = Clustorio
 rcon_static.print = Commands.print
-rcon_static.ipc = Clustorio.send_json
 --- @diagnostic enable: name-style-check
 
 --- Some common callback values which are useful when a player uses the command

--- a/exp_legacy/module/control.lua
+++ b/exp_legacy/module/control.lua
@@ -41,6 +41,6 @@ for _, error in ipairs(errors) do log(error) end
 
 log("[END] -----| Explosive Gaming Scenario Loader |-----")
 
---- Register all event handlers via clusterio
+--- Register all event handlers via event handler
 local Event = require("modules/exp_legacy/utils/event")
 return Event.real_handlers

--- a/exp_legacy/module/utils/event.lua
+++ b/exp_legacy/module/utils/event.lua
@@ -1,4 +1,3 @@
-local Clustorio = require("modules/clusterio/api")
 local ExpUtil = require("modules/exp_util")
 
 local Event = {
@@ -66,7 +65,8 @@ function Event.on_init(handler)
     end
 
     handlers[#handlers + 1] = handler
-    Event.add(Clustorio.events.on_server_startup, handler)
+    Event.add(defines.events.on_singleplayer_init, handler)
+    Event.add(defines.events.on_multiplayer_init, handler)
 end
 
 function Event.on_load(handler)

--- a/exp_util/module/async.lua
+++ b/exp_util/module/async.lua
@@ -408,12 +408,9 @@ end
 local e = defines.events
 local events = {
     [e.on_tick] = on_tick,
+    [e.on_singleplayer_init] = Async.on_init,
+    [e.on_multiplayer_init] = Async.on_init,
 }
-
-local Clustorio = ExpUtil.optional_require("modules/clusterio/api")
-if Clustorio then
-    events[Clustorio.events.on_server_startup] = Async.on_init
-end
 
 Async._function_metatable.__call = Async._function_prototype.start_soon
 Async.events = events --- @package

--- a/exp_util/module/include/package.lua
+++ b/exp_util/module/include/package.lua
@@ -1,7 +1,5 @@
 -- luacheck:ignore global package
 
-local Clustorio = require("modules/clusterio/api")
-
 --- Enum values for the different lifecycle stages within a factorio module
 -- Info on the data lifecycle and how we use it: https://lua-api.factorio.com/latest/auxiliary/data-lifecycle.html
 -- We start in control stage and so values 1 thorough 3 are only present for completeness
@@ -25,10 +23,9 @@ return setmetatable({
     on_load = function() package.lifecycle = package.lifecycle_stage.load end,
     on_configuration_changed = function() package.lifecycle = package.lifecycle_stage.config_change end,
     events = {
-        -- TODO find a reliable way to set to runtime because currently it will desync if accessed before player joined
-        -- TODO make clusterio optional dependency
         [defines.events.on_player_joined_game] = function() package.lifecycle = package.lifecycle_stage.runtime end,
-        [Clustorio.events.on_server_startup] = function() package.lifecycle = package.lifecycle_stage.runtime end,
+        [defines.events.on_singleplayer_init] = function() package.lifecycle = package.lifecycle_stage.runtime end,
+        [defines.events.on_multiplayer_init] = function() package.lifecycle = package.lifecycle_stage.runtime end,
     },
 }, {
     __index = package,

--- a/exp_util/module/storage.lua
+++ b/exp_util/module/storage.lua
@@ -119,12 +119,10 @@ function Storage.on_init()
     end
 end
 
-local events = {}
+--- @package
+Storage.events = {
+    [defines.events.on_multiplayer_init] = Storage.on_init,
+    [defines.events.on_singleplayer_init] = Storage.on_init,
+}
 
-local Clustorio = ExpUtil.optional_require("modules/clusterio/api")
-if Clustorio then
-    events[Clustorio.events.on_server_startup] = Storage.on_init
-end
-
-Storage.events = events --- @package
 return Storage


### PR DESCRIPTION
Rather than using the clusterio startup event, this changes all occurrences to use the singleplayer and multiplayer init events that are called when a save first enters runtime.