### PR TITLE
Pause server ups when no players online

### DIFF
--- a/exp_server_ups/instance.ts
+++ b/exp_server_ups/instance.ts
@@ -24,6 +24,14 @@ export class InstancePlugin extends BaseInstancePlugin {
 		}
 	}
 
+	async onPlayerEvent(event: lib.PlayerEvent): Promise<void> {
+		if (event.type === "join" && !this.updateInterval) {
+			await this.onStart();
+		} else if (event.type === "leave" && this.instance.playersOnline.size == 0 && this.instance.config.get("factorio.settings")["auto_pause"] as boolean) {
+			this.onExit();
+		}
+	}
+
 	async updateUps() {
 		let ups = 0;
 		const collected = this.gameTimes.length - 1;


### PR DESCRIPTION
When the last online player leaves, the update interval is paused to prevent commands being sent to the server. This prevents the slow crawl of 2ups servers even when paused.