### PR TITLE
Bump LuaLS to 3.18.2 in lint workflow

### DIFF
--- a/.github/workflows/fmtk.yml
+++ b/.github/workflows/fmtk.yml
@@ -23,7 +23,7 @@ jobs:
           jq -s '.[0] * .[1].settings' temp.luarc.json ${{ github.workspace }}/factorio/config.json > check.luarc.json
       - name: Install LuaLS
         run: |
-          wget https://github.com/LuaLS/lua-language-server/releases/download/3.15.0/lua-language-server-3.15.0-linux-x64.tar.gz -q -O lusls.tar.gz
+          wget https://github.com/LuaLS/lua-language-server/releases/download/3.18.2/lua-language-server-3.18.2-linux-x64.tar.gz -q -O lusls.tar.gz
           mkdir luals && tar -xf lusls.tar.gz -C luals && rm lusls.tar.gz
       - name: Run Lint Report
         shell: bash


### PR DESCRIPTION
## Summary
Bumps the LuaLS version used by the FMTK lint workflow from `3.15.0` to `3.18.2` (the latest release).

## Why
LuaLS `3.15.0` stack overflows during the `cast-type-mismatch` diagnostic while resolving the recursive function-type aliases used for status returns:

- `Commands.Status` — `fun(msg: LocalisedString?): Commands.Status, LocalisedString` (`exp_commands`)
- `Async.Status` — `(fun(...): Async.Status, ...) | (fun(...): Async.Status, ...)` (`exp_util`)

These aliases are intentional (a function that returns its own type) and valid; the crash is a LuaLS engine bug in `3.15.0` (the `isAlias → isSubType → getClassFields → sign.resolve` loop in the traceback). Reproduced locally with `3.15.0` (stack overflow) and confirmed it disappears when the recursion is removed.

`3.18.2` resolves these aliases correctly and runs the whole repository clean, so no type definitions need to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
