### PR TITLE
repair add quick action, changed to selection

### DIFF
--- a/exp_legacy/module/config/repair.lua
+++ b/exp_legacy/module/config/repair.lua
@@ -2,7 +2,6 @@
 -- @config Repair
 
 return {
-    max_range = 50, --- @setting max_range the max range that can be used with the repair command
     allow_blueprint_repair = false, --- @setting allow_blueprint_repair when true will allow blueprints (things not destroyed by biters) to be build instantly using the repair command
     allow_ghost_revive = true, --- @setting allow_ghost_revive when true will allow ghosts (things destroyed by biters) to be build instantly using the repair command
     allow_heal_entities = true, --- @setting allow_heal_entities when true will heal entities to full health that are within range

--- a/exp_legacy/module/config/repair.lua
+++ b/exp_legacy/module/config/repair.lua
@@ -2,13 +2,6 @@
 -- @config Repair
 
 return {
-    disallow = { --- @setting disallow items in this list will never be repaired
-        ["loader"] = true,
-        ["fast-loader"] = true,
-        ["express-loader"] = true,
-        ["electric-energy-interface"] = true,
-        ["infinity-chest"] = true,
-    },
     max_range = 50, --- @setting max_range the max range that can be used with the repair command
     allow_blueprint_repair = false, --- @setting allow_blueprint_repair when true will allow blueprints (things not destroyed by biters) to be build instantly using the repair command
     allow_ghost_revive = true, --- @setting allow_ghost_revive when true will allow ghosts (things destroyed by biters) to be build instantly using the repair command

--- a/exp_scenario/module/commands/repair.lua
+++ b/exp_scenario/module/commands/repair.lua
@@ -2,61 +2,71 @@
 Adds a command that allows an admin to repair and revive a large area
 ]]
 
+local AABB = require("modules/exp_util/aabb")
 local Commands = require("modules/exp_commands")
 local config = require("modules.exp_legacy.config.repair") --- @dep config.repair
+local Selection = require("modules/exp_util/selection")
+local SelectArea = Selection.connect("ExpCommand_Waterfill")
 
 --- @class ExpCommands_Repair.commands
 local commands = {}
 
---- Repairs entities on your force around you
+--- Toggle player selection mode
 --- @class ExpCommands_Repair.commands.repair: ExpCommand
 commands.repair = Commands.new("repair", { "exp-commands_repair.description" })
     :register(function(player)
-        local force = player.force
-        local surface = player.surface -- Allow remote view
-        local position = player.position -- Allow remote view
-        local response = { "" } --- @type LocalisedString
+        if SelectArea:stop(player) then
+            return Commands.status.success{ "exp-commands_repair.exit" }
+        end
+        SelectArea:start(player)
+        return Commands.status.success{ "exp-commands_repair.enter" }
 
-        if config.allow_ghost_revive then
-            local revive_count = 0
-            local entities = surface.find_entities_filtered{
-                type = "entity-ghost",
-                position = position,
-                radius = config.max_range,
-                force = force,
-            }
+--- When an area is selected to be converted to water
+SelectArea:on_selection(function(event)
+    local area = AABB.expand(event.area)
+    local player = game.players[event.player_index]
+    local surface = event.surface
+    local force = player.force    
+    local response = { "" } --- @type LocalisedString
 
-            local param = { raise_revive = true } --- @type LuaEntity.silent_revive_param
-            for _, entity in ipairs(entities) do
-                if not (entity.ghost_prototype and entity.ghost_prototype.hidden) and (config.allow_blueprint_repair or entity.created_by_corpse) then
-                    revive_count = revive_count + 1
-                    entity.silent_revive(param)
-                end
+    if config.allow_ghost_revive then
+        local revive_count = 0
+        local entities = surface.find_entities_filtered{
+            type = "entity-ghost",
+            area = area,
+            force = force,
+        }
+
+        local param = { raise_revive = true } --- @type LuaEntity.silent_revive_param
+        for _, entity in ipairs(entities) do
+            if not (entity.ghost_prototype and entity.ghost_prototype.hidden) and (config.allow_blueprint_repair or entity.created_by_corpse) then
+                revive_count = revive_count + 1
+                entity.silent_revive(param)
             end
-
-            response[#response + 1] = { "exp-commands_repair.response-revive", revive_count }
         end
 
-        if config.allow_heal_entities then
-            local healed_count = 0
-            local entities = surface.find_entities_filtered{
-                position = position,
-                radius = config.max_range,
-                force = force,
-            }
+        response[#response + 1] = { "exp-commands_repair.response-revive", revive_count }
+    end
 
-            for _, entity in ipairs(entities) do
-                if entity.health and entity.max_health and entity.health ~= entity.max_health then
-                    healed_count = healed_count + 1
-                    entity.health = entity.max_health
-                end
+    if config.allow_heal_entities then
+        local healed_count = 0
+        local entities = surface.find_entities_filtered{
+            area = area,
+            force = force,
+        }
+
+        for _, entity in ipairs(entities) do
+            if entity.health and entity.max_health and entity.health ~= entity.max_health then
+                healed_count = healed_count + 1
+                entity.health = entity.max_health
             end
-
-            response[#response + 1] = { "exp-commands_repair.response-heal", healed_count }
         end
 
-        return Commands.status.success(response)
-    end)
+        response[#response + 1] = { "exp-commands_repair.response-heal", healed_count }
+    end
+
+    return player.print(response)
+end)
 
 return {
     commands = commands,

--- a/exp_scenario/module/commands/repair.lua
+++ b/exp_scenario/module/commands/repair.lua
@@ -5,11 +5,13 @@ Adds a command that allows an admin to repair and revive a large area
 local Commands = require("modules/exp_commands")
 local config = require("modules.exp_legacy.config.repair") --- @dep config.repair
 
+--- @class ExpCommands_Repair.commands
+local commands = {}
+
 --- Repairs entities on your force around you
-Commands.new("repair", { "exp-commands_repair.description" })
-    :argument("range", { "exp-commands_repair.arg-range" }, Commands.types.integer_range(1, config.max_range))
-    :register(function(player, range)
-        --- @cast range number
+--- @class ExpCommands_Repair.commands.repair: ExpCommand
+commands.repair = Commands.new("repair", { "exp-commands_repair.description" })
+    :register(function(player)
         local force = player.force
         local surface = player.surface -- Allow remote view
         local position = player.position -- Allow remote view
@@ -20,13 +22,13 @@ Commands.new("repair", { "exp-commands_repair.description" })
             local entities = surface.find_entities_filtered{
                 type = "entity-ghost",
                 position = position,
-                radius = range,
+                radius = config.max_range,
                 force = force,
             }
 
             local param = { raise_revive = true } --- @type LuaEntity.silent_revive_param
             for _, entity in ipairs(entities) do
-                if not config.disallow[entity.ghost_name] and (config.allow_blueprint_repair or entity.created_by_corpse) then
+                if not (entity.ghost_prototype and entity.ghost_prototype.hidden) and (config.allow_blueprint_repair or entity.created_by_corpse) then
                     revive_count = revive_count + 1
                     entity.silent_revive(param)
                 end
@@ -39,7 +41,7 @@ Commands.new("repair", { "exp-commands_repair.description" })
             local healed_count = 0
             local entities = surface.find_entities_filtered{
                 position = position,
-                radius = range,
+                radius = config.max_range,
                 force = force,
             }
 
@@ -55,3 +57,7 @@ Commands.new("repair", { "exp-commands_repair.description" })
 
         return Commands.status.success(response)
     end)
+
+return {
+    commands = commands,
+}

--- a/exp_scenario/module/commands/repair.lua
+++ b/exp_scenario/module/commands/repair.lua
@@ -20,13 +20,14 @@ commands.repair = Commands.new("repair", { "exp-commands_repair.description" })
         end
         SelectArea:start(player)
         return Commands.status.success{ "exp-commands_repair.enter" }
+    end)
 
 --- When an area is selected to be converted to water
 SelectArea:on_selection(function(event)
+    local player = assert(game.get_player(event.player_index))
     local area = AABB.expand(event.area)
-    local player = game.players[event.player_index]
     local surface = event.surface
-    local force = player.force    
+    local force = player.force
     local response = { "" } --- @type LocalisedString
 
     if config.allow_ghost_revive then

--- a/exp_scenario/module/gui/quick_actions.lua
+++ b/exp_scenario/module/gui/quick_actions.lua
@@ -11,6 +11,7 @@ local addon_research = require("modules/exp_scenario/commands/research")
 local addon_trains = require("modules/exp_scenario/commands/trains")
 local addon_teleport = require("modules/exp_scenario/commands/teleport")
 local addon_waterfill = require("modules/exp_scenario/commands/waterfill")
+local addon_repair = require("modules/exp_scenario/commands/repair")
 
 --- @class ExpGui_QuickActions.elements
 local Elements = {}
@@ -51,6 +52,7 @@ new_quick_action("spawn", addon_teleport.commands.spawn, function(def, player, e
 end)
 
 new_quick_action("waterfill", addon_waterfill.commands.waterfill)
+new_quick_action("repair", addon_repair.commands.repair)
 
 --- Container added to the left gui flow
 --- @class ExpGui_QuickActions.elements.container: ExpElement

--- a/exp_scenario/module/locale/en.cfg
+++ b/exp_scenario/module/locale/en.cfg
@@ -155,7 +155,6 @@ machine-count=And you will need __1__ machines (with the same speed as this one)
 
 [exp-commands_repair]
 description=Repairs entities on your force around you.
-arg-range=Range to repair entities within.
 # Intentional space left on the two lines below so they can be joined together.
 response-revive=__1__ entities were revived. 
 response-heal=__1__ entities were healed. 

--- a/exp_scenario/module/locale/en.cfg
+++ b/exp_scenario/module/locale/en.cfg
@@ -155,6 +155,8 @@ machine-count=And you will need __1__ machines (with the same speed as this one)
 
 [exp-commands_repair]
 description=Repairs entities on your force around you.
+enter=Entered selection mode, select the area.
+exit=Exited selection mode.
 # Intentional space left on the two lines below so they can be joined together.
 response-revive=__1__ entities were revived. 
 response-heal=__1__ entities were healed. 


### PR DESCRIPTION
The hardcoded list is change to using prototype hidden.
This will allow more item to be on the list.
They are not supposed to be acquired from the normal game, so no actual experience harmed.
If you can use them, you are using editor mode anyway.