### PR TITLE
Pin factoriomod-debug to 2.1.3 to fix the lint workflow

### DIFF
--- a/.github/workflows/fmtk.yml
+++ b/.github/workflows/fmtk.yml
@@ -17,7 +17,8 @@ jobs:
           node-version: lts/*
       - name: Install FMTK
         run: |
-          pnpm install factoriomod-debug
+          # Pinned: 2.1.4+ generates typedefs targeting EmmyLua that LuaLS misreads
+          pnpm install factoriomod-debug@2.1.3
           pnpm exec fmtk luals-addon
           jq '.["workspace.library"] += ["${{ github.workspace }}/factorio/library"] | .["runtime.plugin"] = "${{ github.workspace }}/factorio/plugin.lua"' .luarc.json > temp.luarc.json
           jq -s '.[0] * .[1].settings' temp.luarc.json ${{ github.workspace }}/factorio/config.json > check.luarc.json


### PR DESCRIPTION
FMTK Lint has failed on every run since 2026-07-13. The cause is not our code — the workflow installs `factoriomod-debug` unpinned, and FMTK has been retargeting its generated typedefs at EmmyLua, which LuaLS misreads.

Two upstream changes are responsible:

- **2.1.4** switched dict types to `table<K,V>`, so `game.surfaces.nauvis` and `game.forces.player` now report `undefined-field` (8 findings).
- **2.1.5** redefined `LocalisedString` as `[string, LocalisedString...]|…`. LuaLS 3.18.2 cannot match a plain `string` against that variadic tuple, so every `caption = { "key", some_string }` errors — 232 of the 279 findings are this single false positive.

The first failing run lines up with 2.1.5's publish date the same day. Bumping LuaLS is not an option: 3.18.2 is already the latest release.

Verified locally by running CI's exact check (LuaLS 3.18.2 + the merged `.luarc.json`) against addons generated from three FMTK versions, against current `main`:

| FMTK | Findings |
| --- | --- |
| 2.1.3 (last green, 2026-06-25) | 0 |
| 2.1.4 | 11 |
| 2.1.8 (latest) | 279 — matches CI exactly |

So no code changes are needed; the pin alone restores a clean check.

**This is a stopgap.** FMTK's changelog from 2.1.5 onwards states: *"All sumneko/luals users should migrate to emmylua. Support for sumneko/luals will be dropped completely in a near future version, and may already be broken in some areas."* The durable fix is porting the check to `emmylua_check`, which needs a `workspace.moduleMap` to replace the FMTK `runtime.plugin` require rewriting, loses `nameStyle.config` (no equivalent), and surfaces a large backlog of genuine diagnostics. That is worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)