### PR TITLE
Move the community links into a config file

### DIFF
--- a/exp_legacy/module/config/links.lua
+++ b/exp_legacy/module/config/links.lua
@@ -1,0 +1,10 @@
+--- Links to the community, shown in the readme and the join message
+-- @config Links
+
+return {
+    discord = "https://discord.explosivegaming.nl",
+    website = "https://www.explosivegaming.nl",
+    patreon = "https://www.patreon.com/ExpGaming",
+    status = "https://status.explosivegaming.nl",
+    github = "https://github.com/explosivegaming/ExpCluster",
+}

--- a/exp_legacy/module/locale/en/addons.cfg
+++ b/exp_legacy/module/locale/en/addons.cfg
@@ -1,10 +1,3 @@
-[links]
-discord=https://discord.explosivegaming.nl
-website=https://www.explosivegaming.nl
-status=https://status.explosivegaming.nl
-github=https://github.com/explosivegaming/ExpCluster
-patreon=https://www.patreon.com/ExpGaming
-
 [info]
 players-online=There are __1__ players online
 total-map-time=This map has been on for __1__

--- a/exp_legacy/module/locale/zh-CN/addons.cfg
+++ b/exp_legacy/module/locale/zh-CN/addons.cfg
@@ -1,10 +1,3 @@
-[links]
-discord=https://discord.explosivegaming.nl
-website=https://www.explosivegaming.nl
-status=https://status.explosivegaming.nl
-github=https://github.com/explosivegaming/ExpCluster
-patreon=https://www.patreon.com/ExpGaming
-
 [info]
 players-online=現在有 __1__ 人在線
 total-map-time=地圖時間為 __1__

--- a/exp_legacy/module/locale/zh-TW/addons.cfg
+++ b/exp_legacy/module/locale/zh-TW/addons.cfg
@@ -1,10 +1,3 @@
-[links]
-discord=https://discord.explosivegaming.nl
-website=https://www.explosivegaming.nl
-status=https://status.explosivegaming.nl
-github=https://github.com/explosivegaming/ExpCluster
-patreon=https://www.patreon.com/ExpGaming
-
 [info]
 players-online=現在有 __1__ 人在線
 total-map-time=地圖時間為 __1__

--- a/exp_legacy/module/modules/data/greetings.lua
+++ b/exp_legacy/module/modules/data/greetings.lua
@@ -2,6 +2,7 @@
 -- @data Greetings
 
 local config = require("modules.exp_legacy.config.join_messages") --- @dep config.join_messages
+local links = require("modules.exp_legacy.config.links")
 local Commands = require("modules/exp_commands")
 
 --- Stores the join message that the player have
@@ -18,7 +19,7 @@ CustomMessages:on_load(function(player_name, player_message)
     if custom_message then
         game.print(custom_message, { color = player.color })
     else
-        player.print{ "join-message.greet", { "links.discord" } }
+        player.print{ "join-message.greet", links.discord }
     end
 end)
 

--- a/exp_scenario/module/gui/readme.lua
+++ b/exp_scenario/module/gui/readme.lua
@@ -8,6 +8,7 @@ local Roles = require("modules/exp_roles")
 local Commands = require("modules/exp_commands")
 local PlayerData = require("modules.exp_legacy.expcore.player_data")
 local External = require("modules.exp_legacy.expcore.external")
+local links = require("modules.exp_legacy.config.links")
 
 local format_number = require("util").format_number
 local format_time = ExpUtil.format_time_factory_locale{ format = "long", days = true, hours = true, minutes = true }
@@ -336,7 +337,7 @@ define_tab(
         local external_links = Elements.title_table(scroll_pane, 235, { "exp-gui_readme.servers-external" }, 2)
         for _, key in ipairs{ "discord", "website", "patreon", "status", "github" } do
             Gui.elements.centered_label(external_links, 110, key:gsub("^%l", string.upper))
-            Gui.elements.centered_label(external_links, 460, { "links." .. key }, { "exp-gui_readme.servers-open-in-browser" })
+            Gui.elements.centered_label(external_links, 460, links[key], { "exp-gui_readme.servers-open-in-browser" })
         end
 
         return container

--- a/exp_scenario/module/locale/en.cfg
+++ b/exp_scenario/module/locale/en.cfg
@@ -14,7 +14,7 @@ format=[AC] __1__: __2__
 description=Automaticly select enemy target with artillery.
 invalid-area=The selected area is not valid.
 enter=Entered artillery selection mode.
-exit=Existed artillery selection mode.
+exit=Exited artillery selection mode.
 
 [exp-commands_bot-queue]
 description=Get / Set the construction bot queue limits.
@@ -103,8 +103,8 @@ lower-role=You must have a higher role than the target.
 [exp-commands_lawnmower]
 description=Clean up biter corpse, decoratives and nuclear hole.
 arg-range=Range to clean up.
-enter=Entered selection mode, select the area to fill with water.
-exit=Exited selection mode.
+enter=Entered lawnmower selection mode, select the area to clean up.
+exit=Exited lawnmower selection mode.
 complete=__1__ tiles were handled.
 
 [exp-commands_locate]
@@ -158,8 +158,8 @@ machine-count=And you will need __1__ machines (with the same speed as this one)
 
 [exp-commands_repair]
 description=Repairs entities on your force around you.
-enter=Entered selection mode, select the area.
-exit=Exited selection mode.
+enter=Entered repair selection mode, select the area to repair.
+exit=Exited repair selection mode.
 # Intentional space left on the two lines below so they can be joined together.
 response-revive=__1__ entities were revived. 
 response-heal=__1__ entities were healed. 
@@ -223,8 +223,8 @@ description-blueprints-surface=Clear all blueprints on the current surface.
 arg-surface=Surface to clear on, default all.
 items=__1__ cleared all items on the ground of __2__.
 blueprints=__1__ cleared all blueprints on __2__.
-enter=Entered selection mode, select the area.
-exit=Exited selection mode.
+enter=Entered blueprint selection mode, select the area to clear blueprints from.
+exit=Exited blueprint selection mode.
 complete=__1__ blueprint ghost were removed.
 
 [exp-commands_trains]


### PR DESCRIPTION
Fixes #424.

The five community links were locale strings repeated in every language. They are now `exp_legacy/config/links.lua`, read by the readme's external links table and the join greeting, and the `[links]` sections are removed from all three locales.

For the selection mode messages I kept per command keys, since each carries its own hint, but fixed the wording where it was wrong or empty: the lawnmower said it would fill the area with water, repair and blueprint clearing had a generic "select the area", and artillery had "Existed" for exited. If you would rather have one shared section in exp_util's selection module with the command name as a parameter, say so and I will follow up.

Lua lint is clean, and on my dev instance the config loads and the readme resolves the links from it.
