### PR TITLE
Encode group permissions as a 1-based array

### DIFF
--- a/exp_groups/module/control.lua
+++ b/exp_groups/module/control.lua
@@ -102,11 +102,11 @@ local function encode_group_permissions(group)
     local allows_action = group.allows_action
     for input_action_name, input_action in pairs(defines.input_action) do
         if allows_action(input_action) then
-            whitelist[whitelist_index] = input_action_name
             whitelist_index = whitelist_index + 1
+            whitelist[whitelist_index] = input_action_name
         else
-            blacklist[blacklist_index] = input_action_name
             blacklist_index = blacklist_index + 1
+            blacklist[blacklist_index] = input_action_name
         end
     end
 


### PR DESCRIPTION
Every in-game permission group edit with sync enabled logged `Error handling ipc event: Request exp_groups:GroupUpdateRequest failed validation` on the host and never reached the controller.

`encode_group_permissions` filled the whitelist and blacklist tables starting at index 0. Factorio's `table_to_json` only treats a table as a JSON array when its keys run 1..n, so a zero-based table comes out as `{"0":"a","1":"b"}`. The instance plugin passed that object through to `GroupPermissions`, whose schema requires an array of strings, and the request was rejected before sending. The fix increments the counter before assigning so the tables are 1-based. The size comparison and the empty-list guards below are unchanged.

I confirmed the serialisation with a throwaway scenario on headless 2.1.17: `{[0]="a",[1]="b",[2]="c"}` encodes as `{"1":"b","2":"c","0":"a"}` while `{"a","b","c"}` encodes as `["a","b","c"]`. The bug has been present since the module was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)