### PR TITLE
Reference exp_roles and exp_groups from the exp_scenario build

### DIFF
--- a/exp_groups/index.ts
+++ b/exp_groups/index.ts
@@ -1,6 +1,9 @@
 import * as lib from "@clusterio/lib";
 import * as messages from "./messages";
 
+export * from "./messages";
+export type { ControllerPlugin } from "./controller";
+
 declare module "@clusterio/lib" {
 	export interface InstanceConfigFields {
 		"exp_groups.sync_mode": "enabled" | "disabled" | "bidirectional"

--- a/exp_roles/index.ts
+++ b/exp_roles/index.ts
@@ -1,6 +1,9 @@
 import * as lib from "@clusterio/lib";
 import * as messages from "./messages";
 
+export * from "./messages";
+export type { ControllerPlugin } from "./controller";
+
 declare module "@clusterio/lib" {
 	export interface InstanceConfigFields {
 		"exp_roles.sync_mode": "disabled" | "enabled" | "bidirectional";

--- a/exp_scenario/controller.ts
+++ b/exp_scenario/controller.ts
@@ -1,9 +1,9 @@
 import * as lib from "@clusterio/lib";
 import { BaseControllerPlugin } from "@clusterio/controller";
-import type { ControllerPlugin as RolesPlugin } from "@expcluster/roles/dist/node/controller";
-import type { ControllerPlugin as GroupsPlugin } from "@expcluster/permission-groups/dist/node/controller";
-import { RoleMetaRecord } from "@expcluster/roles/dist/node/messages";
-import { GroupRecord, GroupPermissions, RoleMappingRecord } from "@expcluster/permission-groups/dist/node/messages";
+import { RoleMetaRecord, type ControllerPlugin as RolesPlugin } from "@expcluster/roles";
+import {
+	GroupRecord, GroupPermissions, RoleMappingRecord, type ControllerPlugin as GroupsPlugin,
+} from "@expcluster/permission-groups";
 import * as messages from "./messages";
 import { SeedRole, SeedGroup, seedRoles, seedGroups, flattenSeedPermissions } from "./seed";
 

--- a/exp_scenario/seed.ts
+++ b/exp_scenario/seed.ts
@@ -1,4 +1,4 @@
-import { RoleColor } from "@expcluster/roles/dist/node/messages";
+import { RoleColor } from "@expcluster/roles";
 
 /**
  * A role created by the seed, as the scenario defined it before roles moved to

--- a/exp_scenario/test/controller.test.js
+++ b/exp_scenario/test/controller.test.js
@@ -5,11 +5,11 @@ const { Controller } = require("@clusterio/controller");
 const { ControllerPlugin } = require("../dist/node/controller");
 const messages = require("../dist/node/messages");
 const { seedRoles, seedGroups } = require("../dist/node/seed");
-const roles = require("@expcluster/roles/dist/node");
-const groups = require("@expcluster/permission-groups/dist/node");
+const roles = require("@expcluster/roles");
+const groups = require("@expcluster/permission-groups");
 const { ControllerPlugin: RolesPlugin } = require("@expcluster/roles/dist/node/controller");
 const { ControllerPlugin: GroupsPlugin } = require("@expcluster/permission-groups/dist/node/controller");
-const { GroupRecord, GroupPermissions, RoleMappingRecord } = require("@expcluster/permission-groups/dist/node/messages");
+const { GroupRecord, GroupPermissions, RoleMappingRecord } = require("@expcluster/permission-groups");
 
 // Importing this defines the permissions the seed grants
 require("../dist/node/permissions");

--- a/exp_scenario/tsconfig.node.json
+++ b/exp_scenario/tsconfig.node.json
@@ -1,5 +1,9 @@
 {
 	"extends": "../tsconfig.node.json",
+	"references": [
+		{ "path": "../exp_groups/tsconfig.node.json" },
+		{ "path": "../exp_roles/tsconfig.node.json" },
+	],
 	"include": ["./**/*.ts"],
 	"exclude": ["test/*", "./dist/*"],
 }


### PR DESCRIPTION
Since #457 exp_scenario imports types from `@expcluster/roles` and `@expcluster/permission-groups`. Their declaration files only exist once the two packages have been built, so building exp_scenario before them fails with `TS2307: Cannot find module '@expcluster/roles/dist/node/controller'` and four more like it. A plain `pnpm install` gets away with it because pnpm runs the prepare scripts in dependency order, but a filtered install, or `tsc --build` inside exp_scenario on a fresh clone, hits the error.

Two commits:

1. Project references from exp_scenario's node tsconfig to the node tsconfigs of exp_roles and exp_groups, the same way the core clusterio plugins reference `packages/lib`. `tsc --build` now builds those two first when they are out of date.
2. exp_roles and exp_groups re-export their messages and the `ControllerPlugin` type from the package index, so exp_scenario imports `from "@expcluster/roles"` instead of `from "@expcluster/roles/dist/node/messages"`. The controller export is type only, so nothing from `@clusterio/controller` ends up in the web bundle (checked the emitted index chunk). The test keeps the deep require for the controller classes since those cannot be re-exported at runtime.

Verified by deleting every `dist` folder and running `tsc --build` in exp_scenario alone, then at the repo root, plus webpack for all three packages and the roles and scenario tap suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)