### PR TITLE
Add a Node.js CI workflow that builds and tests inside clusterio

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -9,38 +9,40 @@ env:
   # inside a clusterio checkout with this repository under external_plugins
   CLUSTERIO_REPOSITORY: clusterio/clusterio
   CLUSTERIO_REF: master
+  # Node version to use for the tests. This is used by the setup-node action
+  NODE_VERSION: lts/*
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
     defaults:
       run:
         working-directory: external_plugins/ExpCluster
     steps:
-      - name: Checkout clusterio
+      - name: Checkout Clusterio
         uses: actions/checkout@v4
         with:
           repository: ${{ env.CLUSTERIO_REPOSITORY }}
           ref: ${{ env.CLUSTERIO_REF }}
-      - name: Checkout ExpCluster into the workspace
+      - name: Checkout ExpCluster
         uses: actions/checkout@v4
         with:
           path: external_plugins/ExpCluster
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
-      - name: Install and build the workspace
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Install and build
         working-directory: .
         run: pnpm install --no-frozen-lockfile
       - name: Run tests
         run: pnpm --filter "@expcluster/*" run test
-      - name: Build each package on its own
+      - name: Run reference checks
         run: |
-          # pnpm install runs prepare in dependency order, which hides a missing
-          # project reference (#473). Building from an empty dist one package at
-          # a time fails unless every cross package import is referenced.
+          # pnpm install runs prepare in dependency order, which hides missing
+          # project references. Building from an empty dist one package at a time
+          # will fail unless every cross package import is referenced correctly.
           for pkg in exp_*/; do
             rm -rf exp_*/dist
             echo "::group::${pkg%/}"

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,49 @@
+name: Node.js CI
+
+on:
+  push:
+  pull_request:
+
+env:
+  # The packages use workspace:^ and catalog: versions, so they only resolve
+  # inside a clusterio checkout with this repository under external_plugins
+  CLUSTERIO_REPOSITORY: clusterio/clusterio
+  CLUSTERIO_REF: master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: external_plugins/ExpCluster
+    steps:
+      - name: Checkout clusterio
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.CLUSTERIO_REPOSITORY }}
+          ref: ${{ env.CLUSTERIO_REF }}
+      - name: Checkout ExpCluster into the workspace
+        uses: actions/checkout@v4
+        with:
+          path: external_plugins/ExpCluster
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install and build the workspace
+        working-directory: .
+        run: pnpm install --no-frozen-lockfile
+      - name: Run tests
+        run: pnpm --filter "@expcluster/*" run test
+      - name: Build each package on its own
+        run: |
+          # pnpm install runs prepare in dependency order, which hides a missing
+          # project reference (#473). Building from an empty dist one package at
+          # a time fails unless every cross package import is referenced.
+          for pkg in exp_*/; do
+            rm -rf exp_*/dist
+            echo "::group::${pkg%/}"
+            (cd "$pkg" && pnpm exec tsc --build)
+            echo "::endgroup::"
+          done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ For developers wanting to add features please follow these guidelines:
 - Lua is checked with [emmylua](https://github.com/EmmyLuaLs/emmylua-analyzer-rust), configured by `.emmyrc.json`. Install the EmmyLua extension rather than sumnekolua / luals, and use factoriomod-debug to generate the factorio api types. Note that an inline cast must be written `--[[@as T]]`, the spaced form is not parsed.
 - Changes should be made on your own fork and merged into `main` through a pull request.
 - Each pull request should be limited to one feature or a few bug fixes and link to the related issue page.
-- Pull requests are automatically linted and documentation checked.
+- Pull requests are automatically linted, then built and tested against the latest clusterio `master`.
 - Pull requests are manually reviewed to maintain code and language quality.
 - New features should have the branch names: `feature/feature-name`
 - Bug fixes should have the branch names: `fix/bug-name`


### PR DESCRIPTION
Follow up to #473. There was no CI for the TypeScript side, so a package that only builds when its siblings happen to be built first went unnoticed until someone hit it on a fresh clone.

The packages use `workspace:^` and `catalog:` versions, so they only resolve inside a clusterio checkout with this repository under `external_plugins`. The new `node.yml` workflow reproduces that layout on the runner: it checks out `clusterio/clusterio` master at the workspace root, checks this repository out into `external_plugins/ExpCluster`, runs `pnpm install --no-frozen-lockfile` (clusterio does not commit a lockfile, and pnpm refuses to install without one in CI otherwise), which runs every `prepare` script, and then runs the tap suites with `pnpm --filter "@expcluster/*" run test`.

The last step is the one that would have caught #473. It wipes every `dist` folder and runs `tsc --build` inside each package on its own. `pnpm install` builds packages in dependency order, so a missing project reference never shows up there. On the commit before #473 this step fails with the same five `TS2307` errors reported in that PR; on `main` it passes.

The clusterio repository and ref are two `env` values at the top of the workflow, so pinning to a tag later is a one line change. CONTRIBUTING.md now mentions the build and test run.

Verified locally by cloning clusterio master with ExpCluster main under `external_plugins` and running each step: install 39 s, tests 523 + 575 passing, isolated builds 8 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
